### PR TITLE
Issue 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ class Banner {
 
     async _reset(term){
         const data = querystring.stringify({
-            'uniqueSessionId': Math.random().toString(36).substr(2,5) + Date.now(),
             'term': term
         });
 
@@ -85,10 +84,10 @@ class Banner {
             throw new Error('Must provide term');
         }
         const path = '/classSearch/get_instructor';
-        const idxs = [...Array(this.School.instrMax / this.PageSizes.instructors).keys()].map(i => i + 1);
+        const idxs = [...Array(this.School.instrMax / this.PageSizes.instructors).keys()];
         let res = await Promise.all(idxs.map(async idx => {
             const params = querystring.stringify({
-                offset: idx,
+                offset: ++idx,
                 max: this.PageSizes.instructors,
                 term: term
             });
@@ -153,8 +152,7 @@ class Banner {
             txt_subject: subject,
             txt_term: term,
             pageOffset: 0,
-            pageMaxSize: -1,
-            uniqueSessionId: this.SessionId
+            pageMaxSize: -1
         };
         if (openOnly) params.chk_open_only = true;
         params = querystring.stringify(params);
@@ -183,8 +181,7 @@ class Banner {
             txt_subject: subject,
             txt_term: term,
             pageOffset: 0,
-            pageMaxSize: -1,
-            uniqueSessionId: this.SessionId
+            pageMaxSize: -1
         };
         params = querystring.stringify(params);
 
@@ -197,7 +194,6 @@ class Banner {
                 'Cookie': await cookie     
             }
         };
-        await reset;
         let res = await promiseRequest(options);
         return res.Data.data;
     }

--- a/index.js
+++ b/index.js
@@ -13,15 +13,18 @@ class Banner {
         if (arguments.length < 1 || school === undefined || school === null){
             throw new Error('Must provide school name');
         }
+
+        if (config[school] === undefined){
+            throw new Error('Invalid school');
+        }
         this.School = config[school];
-        this.SessionId = Date.now();
         this.BasePath = config.global.basePath;
         this.PageSizes = config.global.pageSizes;
     }
 
-    async _init(term){
+    async _reset(term){
         const data = querystring.stringify({
-            'uniqueSessionId': this.SessionId,
+            'uniqueSessionId': Math.random().toString(36).substr(2,5) + Date.now(),
             'term': term
         });
 
@@ -36,7 +39,7 @@ class Banner {
         };
 
         let res = await promiseRequest(options, data);
-        this.Cookie = res.Response.headers['set-cookie'];
+        return res.Response.headers['set-cookie'];
     }
 
     async getTerms(){
@@ -144,7 +147,7 @@ class Banner {
         if (arguments.length < 2){
             throw new Error('Must provide term and subject');
         }
-        let reset = this._init(term);
+        let cookie = this._reset(term);
         const path = '/searchResults';
         let params = {
             txt_subject: subject,
@@ -156,14 +159,13 @@ class Banner {
         if (openOnly) params.chk_open_only = true;
         params = querystring.stringify(params);
 
-        await reset;
         const options = {
             method: 'GET',
             hostname: this.School.host,
             path: `${this.BasePath}${path}?${params}`,
             port: 443,
             headers: {
-                'Cookie': this.Cookie     
+                'Cookie': await cookie    
             }
         };
         
@@ -175,7 +177,7 @@ class Banner {
         if (arguments.length < 2){
             throw new Error('Must provide term and subject');
         }
-        let reset = this._init(term);
+        let cookie = this._reset(term);
         const path = '/courseSearchResults';
         let params = {
             txt_subject: subject,
@@ -192,7 +194,7 @@ class Banner {
             path: `${this.BasePath}${path}?${params}`,
             port: 443,
             headers: {
-                'Cookie': this.Cookie     
+                'Cookie': await cookie     
             }
         };
         await reset;

--- a/test/temple.js
+++ b/test/temple.js
@@ -21,13 +21,15 @@ describe('Banner', function () {
   });
 
   /**
-   * _INIT()
+   * _RESET()
    */
-  describe('#_init()', function () {
-    it('Should set Banner.Cookie value', async function () {
-      let b = new Banner(school);
-      await b._init(term);
-      assert.strict(banner.Cookie);
+  describe('#_reset()', function () {
+    it('Should return cookie value', async function () {
+      let banner = new Banner(school);
+      let cookie = await banner._reset(term)
+      assert.strict(cookie.length === 2);
+      assert.strict(cookie[0].startsWith('JSESSIONID'));
+      assert.strict(cookie[1].startsWith('BIGipServer'));
     });
   });
 
@@ -59,7 +61,7 @@ describe('Banner', function () {
    */
   describe('#getSubjects()', function () {
     it('Should throw an error when a term is not passed', function () {
-      assert.rejects(() => banner.getSubjects(), Error, 'Must provide term');
+      assert.rejects(async () => await banner.getSubjects(), Error, 'Must provide term');
     });
 
     it('Should not return void', async function () {
@@ -133,7 +135,7 @@ describe('Banner', function () {
     this.timeout(15000);
     var data = null;
     it('Should throw an error when a term is not passed', function () {
-      assert.rejects(() => banner.getInstructors(), Error, 'Must provide term');
+      assert.rejects(async () => await banner.getInstructors(), Error, 'Must provide term');
     });
 
     it('Should not return void', async function () {
@@ -153,7 +155,7 @@ describe('Banner', function () {
     this.timeout(30000);
     var data = null;
     it('Should throw an error when a subject and term are not passed', function () {
-      assert.rejects(async () => banner.classSearch, Error, 'Must provide term and subject');
+      assert.rejects(async () =>await banner.classSearch(), Error, 'Must provide term and subject');
     });
 
     it('Should not return NULL', async function(){
@@ -173,7 +175,7 @@ describe('Banner', function () {
     this.timeout(30000);
     var data = null;
     it('Should throw an error when a term and subject are not passed', function () {
-      assert.rejects(async () => banner.catalogSearch, Error, 'Must provide term and subject');
+      assert.rejects(async () => await banner.catalogSearch(), Error, 'Must provide term and subject');
     });
 
     it('Should not return NULL', async function(){
@@ -193,7 +195,7 @@ describe('Banner', function () {
     this.timeout(30000);
     var data = null;
     it('Should throw an error when a term is not passed', function () {
-      assert.rejects(() => banner.getAllCourses(), Error, 'Must provide term');
+      assert.rejects(async () => await banner.getAllCourses(), Error, 'Must provide term');
     });
 
     it('Should not return NULL', async function(){

--- a/test/temple.js
+++ b/test/temple.js
@@ -10,6 +10,7 @@ describe('Banner', function () {
    */
   const school = 'temple';
   const term = 202003;
+  var cache = {};
 
   /**
    * CONSTRUCTOR
@@ -21,11 +22,15 @@ describe('Banner', function () {
   });
 
   /**
+   * SETUP
+   */
+  var banner = new Banner(school);
+
+  /**
    * _RESET()
    */
   describe('#_reset()', function () {
     it('Should return cookie value', async function () {
-      let banner = new Banner(school);
       let cookie = await banner._reset(term)
       assert.strict(cookie.length === 2);
       assert.strict(cookie[0].startsWith('JSESSIONID'));
@@ -33,26 +38,27 @@ describe('Banner', function () {
     });
   });
 
-  /**
-   * SETUP
-   */
-  var banner = new Banner(school);
+  
 
   /**
    * GET_TERMS()
    */
   describe('#getTerms()', function () {
-    it('Should not throw an error', async function () {
-      assert.doesNotReject(banner.getTerms());
+
+    before(async () => {
+      cache.terms = await banner.getTerms();
     });
 
-    it('Should not return void', async function () {
-      assert.strict(await banner.getTerms());
+    it('Should not throw an error', function () {
+      assert.doesNotReject(async () => await banner.getTerms());
     });
 
-    it('Should return a non-empty array', async function () {
-      let terms = await banner.getTerms();
-      assert.strict(terms.length > 0);
+    it('Should not return void', function () {
+      assert.strict(cache.terms);
+    });
+
+    it('Should return a non-empty array', function () {
+      assert.strict(cache.terms.length > 0);
     });
   });
 
@@ -60,17 +66,21 @@ describe('Banner', function () {
    * GETSUBJECTS()
    */
   describe('#getSubjects()', function () {
+
+    before(async () => {
+      cache.subjects = await banner.getSubjects(term);
+    });
+
     it('Should throw an error when a term is not passed', function () {
       assert.rejects(async () => await banner.getSubjects(), Error, 'Must provide term');
     });
 
-    it('Should not return void', async function () {
-      assert.strict(await banner.getSubjects(term));
+    it('Should not return void', function () {
+      assert.strict(cache.subjects);
     });
 
-    it('Should return a non-empty array', async function () {
-      let terms = await banner.getSubjects(term);
-      assert.strict(terms.length > 0);
+    it('Should return a non-empty array', function () {
+      assert.strict(cache.subjects.length > 0);
     });
   });
 
@@ -78,17 +88,21 @@ describe('Banner', function () {
    * GETCAMPUS()
    */
   describe('#getCampus()', function () {
-    it('Should not throw an error', async function () {
-      assert.doesNotReject(banner.getCampus());
+
+    before(async () => {
+      cache.campus = await banner.getCampus();
     });
 
-    it('Should not return void', async function () {
-      assert.strict(await banner.getCampus());
+    it('Should not throw an error', function () {
+      assert.doesNotReject(async () => await banner.getCampus());
     });
 
-    it('Should return a non-empty array', async function () {
-      let terms = await banner.getCampus();
-      assert.strict(terms.length > 0);
+    it('Should not return void', function () {
+      assert.strict(cache.campus);
+    });
+
+    it('Should return a non-empty array', function () {
+      assert.strict(cache.campus.length > 0);
     });
   });
 
@@ -96,17 +110,21 @@ describe('Banner', function () {
    * GETCOLLEGES()
    */
   describe('#getColleges()', function () {
-    it('Should not throw an error', async function () {
-      assert.doesNotReject(banner.getColleges());
+
+    before(async () => {
+      cache.colleges = await banner.getColleges();
     });
 
-    it('Should not return void', async function () {
-      assert.strict(await banner.getColleges());
+    it('Should not throw an error', function () {
+      assert.doesNotReject(async () => await banner.getColleges());
     });
 
-    it('Should return a non-empty array', async function () {
-      let terms = await banner.getColleges();
-      assert.strict(terms.length > 0);
+    it('Should not return void', function () {
+      assert.strict(cache.colleges);
+    });
+
+    it('Should return a non-empty array', function () {
+      assert.strict(cache.colleges.length > 0);
     });
   });
 
@@ -114,17 +132,21 @@ describe('Banner', function () {
    * GETATTRIBUTES()
    */
   describe('#getAttributes()', function () {
-    it('Should not throw an error', async function () {
-      assert.doesNotReject(banner.getAttributes());
+
+    before(async () => {
+      cache.attributes = await banner.getAttributes();
     });
 
-    it('Should not return void', async function () {
-      assert.strict(await banner.getAttributes());
+    it('Should not throw an error', function () {
+      assert.doesNotReject(async () => await banner.getAttributes());
     });
 
-    it('Should return a non-empty array', async function () {
-      let terms = await banner.getAttributes();
-      assert.strict(terms.length > 0);
+    it('Should not return void', function () {
+      assert.strict(cache.attributes);
+    });
+
+    it('Should return a non-empty array', function () {
+      assert.strict(cache.attributes.length > 0);
     });
   });
 
@@ -133,18 +155,21 @@ describe('Banner', function () {
    */
   describe('#getInstructors()', function () {
     this.timeout(15000);
-    var data = null;
+
+    before(async () => {
+      cache.instructors = await banner.getInstructors(term);
+    });
+
     it('Should throw an error when a term is not passed', function () {
       assert.rejects(async () => await banner.getInstructors(), Error, 'Must provide term');
     });
 
-    it('Should not return void', async function () {
-      data = await banner.getInstructors(term);
-      assert.strict(data);
+    it('Should not return void', function () {
+      assert.strict(cache.instructors);
     });
 
     it('Should return a non-empty array', function () {
-      assert.strict(data.length > 0);
+      assert.strict(cache.instructors.length > 0);
     });
   });
 
@@ -153,18 +178,21 @@ describe('Banner', function () {
    */
   describe('#classSearch(subjects)', function () {
     this.timeout(30000);
-    var data = null;
+
+    before(async () => {
+      cache.classes = await banner.classSearch(term, 'CIS');
+    });
+
     it('Should throw an error when a subject and term are not passed', function () {
       assert.rejects(async () =>await banner.classSearch(), Error, 'Must provide term and subject');
     });
 
-    it('Should not return NULL', async function(){
-      data = await banner.classSearch(term, 'CIS');
-      assert.strict(data);
+    it('Should not return NULL', function(){
+      assert.strict(cache.classes);
     });
 
     it('Should return a non-empty array', function () {
-      assert.strict(data.length > 0);
+      assert.strict(cache.classes.length > 0);
     });
   });
 
@@ -173,18 +201,21 @@ describe('Banner', function () {
    */
   describe('#catalogSearch(subjects)', function () {
     this.timeout(30000);
-    var data = null;
+
+    before(async () => {
+      cache.catalog = await banner.catalogSearch(term, 'CIS');
+    });
+
     it('Should throw an error when a term and subject are not passed', function () {
       assert.rejects(async () => await banner.catalogSearch(), Error, 'Must provide term and subject');
     });
 
-    it('Should not return NULL', async function(){
-      data = await banner.catalogSearch(term, 'CIS');
-      assert.strict(data);
+    it('Should not return NULL', function(){
+      assert.strict(cache.catalog);
     });
 
     it('Should return a non-empty array', function () {
-      assert.strict(data.length > 0);
+      assert.strict(cache.catalog.length > 0);
     });
   });
 
@@ -193,18 +224,26 @@ describe('Banner', function () {
    */
   describe('#getAllCourses()', function () {
     this.timeout(30000);
-    var data = null;
+
+    before(async () => {
+      cache.courses = await banner.getAllCourses(term);
+    });
+
     it('Should throw an error when a term is not passed', function () {
       assert.rejects(async () => await banner.getAllCourses(), Error, 'Must provide term');
     });
 
-    it('Should not return NULL', async function(){
-      data = await banner.getAllCourses(term);
-      assert.strict(data);
+    it('Should not return NULL', function(){
+      assert.strict(cache.courses);
     });
 
     it('Should return a non-empty array', function () {
-      assert.strict(data.length > 0);
+      assert.strict(cache.courses.length > 0);
+    });
+
+    it('Should retrieve courses for each subject', function () {
+      let uniqueSubjects = [...new Set(cache.courses.map(item => item.subject))];
+      assert.strict(cache.subjects.length === uniqueSubjects.length);
     });
   });
 });


### PR DESCRIPTION
- Removed Session ID (Not actually needed, just cookie)

- renamed `_init` to `_reset` to better reflect function

- Cookie is now properly set for methods that require it ([#2](https://github.com/schedulemaker/bannerjs/issues/2))

- Implemented data cache  for unit tests

- `getAllCourses` now returns courses for every subject ([#1](https://github.com/schedulemaker/bannerjs/issues/1))

